### PR TITLE
Selected Item is out of bounds.

### DIFF
--- a/AKPickerView/AKPickerView.swift
+++ b/AKPickerView/AKPickerView.swift
@@ -415,7 +415,7 @@ public class AKPickerView: UIView, UICollectionViewDataSource, UICollectionViewD
 		self.invalidateIntrinsicContentSize()
 		self.collectionView.collectionViewLayout.invalidateLayout()
 		self.collectionView.reloadData()
-		if self.dataSource != nil && self.dataSource!.numberOfItemsInPickerView(self) > 0 {
+		if self.dataSource != nil && self.dataSource!.numberOfItemsInPickerView(self) > 0 && self.dataSource!.numberOfItemsInPickerView(self) > self.selectedItem {
 			self.selectItem(self.selectedItem, animated: false, notifySelection: false)
 		}
 	}


### PR DESCRIPTION
When data changes and the picker is reload, selected item index can be out of bounds.

To prevent that, I check in reloadData method the number of items in the picker view if it's bigger than selected item index. If this index is out, the picker don't scroll.
