### PR TITLE
Several properties made IBInspectable

### DIFF
--- a/AKPickerView/AKPickerView.swift
+++ b/AKPickerView/AKPickerView.swift
@@ -240,18 +240,24 @@ public class AKPickerView: UIView, UICollectionViewDataSource, UICollectionViewD
 	}
 	/// Readwrite. A font which used in NOT selected cells.
 	public lazy var font = UIFont.systemFontOfSize(20)
+    
 	/// Readwrite. A font which used in selected cells.
 	public lazy var highlightedFont = UIFont.boldSystemFontOfSize(20)
+    
 	/// Readwrite. A color of the text on NOT selected cells.
-	public lazy var textColor = UIColor.darkGrayColor()
+    @IBInspectable public lazy var textColor: UIColor = UIColor.darkGrayColor()
+    
 	/// Readwrite. A color of the text on selected cells.
-	public lazy var highlightedTextColor = UIColor.blackColor()
+    @IBInspectable public lazy var highlightedTextColor: UIColor = UIColor.blackColor()
+    
 	/// Readwrite. A float value which indicates the spacing between cells.
-	public var interitemSpacing: CGFloat = 0.0
+    @IBInspectable public var interitemSpacing: CGFloat = 0.0
+    
 	/// Readwrite. The style of the picker view. See AKPickerViewStyle.
 	public var pickerViewStyle = AKPickerViewStyle.Wheel
+    
 	/// Readwrite. A float value which determines the perspective representation which used when using AKPickerViewStyle.Wheel style.
-	public var viewDepth: CGFloat = 1000.0 {
+	@IBInspectable public var viewDepth: CGFloat = 1000.0 {
 		didSet {
 			self.collectionView.layer.sublayerTransform = self.viewDepth > 0.0 ? {
 				var transform = CATransform3DIdentity;
@@ -261,7 +267,7 @@ public class AKPickerView: UIView, UICollectionViewDataSource, UICollectionViewD
 		}
 	}
 	/// Readwrite. A boolean value indicates whether the mask is disabled.
-	public var maskDisabled: Bool! = nil {
+	@IBInspectable public var maskDisabled: Bool! = nil {
 		didSet {
 			self.collectionView.layer.mask = self.maskDisabled == true ? nil : {
 				let maskLayer = CAGradientLayer()

--- a/AKPickerViewSample/Base.lproj/Main.storyboard
+++ b/AKPickerViewSample/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -19,6 +19,14 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ObD-nA-s2m" customClass="AKPickerView" customModule="AKPickerViewSample" customModuleProvider="target">
                                 <rect key="frame" x="50" y="50" width="500" height="500"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="interitemSpacing">
+                                        <real key="value" value="20"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="viewDepth">
+                                        <real key="value" value="1000"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>

--- a/AKPickerViewSample/ViewController.swift
+++ b/AKPickerViewSample/ViewController.swift
@@ -21,8 +21,6 @@ class ViewController: UIViewController, AKPickerViewDataSource, AKPickerViewDele
 
 		self.pickerView.font = UIFont(name: "HelveticaNeue-Light", size: 20)!
 		self.pickerView.highlightedFont = UIFont(name: "HelveticaNeue", size: 20)!
-		self.pickerView.interitemSpacing = 20.0
-		self.pickerView.viewDepth = 1000.0
 		self.pickerView.pickerViewStyle = .Wheel
 		self.pickerView.maskDisabled = false
 		self.pickerView.reloadData()


### PR DESCRIPTION
Hi there,
I'm currently using your picker view in an app that I'm making and I thought I would make several of the properties IBInspectable so that they can be edited with Interface Builder rather than in the code. The properties are the text color, highlighted text color, interitem spacing, view depth, and mask disabled.  This way, other developers who are using this don't have to set these values directly in their code. I might also work on displaying a mock version of the picker that only displays at design time on Interface Builder, making it easier to visualize where it will show up on the view controller.
