### PR TITLE
Updated selectedItem's getter to be public

### DIFF
--- a/AKPickerView/AKPickerView.swift
+++ b/AKPickerView/AKPickerView.swift
@@ -286,7 +286,7 @@ public class AKPickerView: UIView, UICollectionViewDataSource, UICollectionViewD
 
 	// MARK: Readonly Properties
 	/// Readonly. Index of currently selected item.
-	private(set) var selectedItem: Int = 0
+	public private(set) var selectedItem: Int = 0
 	/// Readonly. The point at which the origin of the content view is offset from the origin of the picker view.
 	public var contentOffset: CGPoint {
 		get {


### PR DESCRIPTION
I noticed that the selectedItem property's getter isn't public, so I've added 'public' keyword. I believe this is what was intended.
