### PR TITLE
Update Readme to reflect correct import

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pod "AKPickerView-Swift"
 ```
 And in your `*.swift`:
 ```swift
-import AKPickerView_Swift
+import AKPickerView
 ```
 
 ###[Carthage](https://github.com/Carthage/Carthage):


### PR DESCRIPTION
The module is created as AKPickerView so importing AKPickerView_Swift should be `import AKPickerView` 
