### PR TITLE
Add optional delegate method didPressItem:

### DIFF
--- a/AKPickerView-Swift.podspec
+++ b/AKPickerView-Swift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name = 'AKPickerView-Swift'
-    s.version = '1.0.1'
+    s.version = '1.0.2'
     s.summary = 'A simple yet customizable horizontal picker view.'
 
     s.description  = 'A simple yet customizable horizontal picker view. Works on iOS 8'

--- a/AKPickerView/AKPickerView.swift
+++ b/AKPickerView/AKPickerView.swift
@@ -37,6 +37,7 @@ and customize the appearance of labels.
 */
 @objc public protocol AKPickerViewDelegate: UIScrollViewDelegate {
 	optional func pickerView(pickerView: AKPickerView, didSelectItem item: Int)
+	optional func pickerView(pickerView: AKPickerView, didPressItem item: Int)
 	optional func pickerView(pickerView: AKPickerView, marginForItem item: Int) -> CGSize
 	optional func pickerView(pickerView: AKPickerView, configureLabel label: UILabel, forItem item: Int)
 }
@@ -283,6 +284,8 @@ public class AKPickerView: UIView, UICollectionViewDataSource, UICollectionViewD
 				}()
 		}
 	}
+
+	public var pressShouldFireSelectedEvent = true
 
 	// MARK: Readonly Properties
 	/// Readonly. Index of currently selected item.
@@ -574,7 +577,8 @@ public class AKPickerView: UIView, UICollectionViewDataSource, UICollectionViewD
 
 	// MARK: UICollectionViewDelegate
 	public func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
-		self.selectItem(indexPath.item, animated: true)
+		self.selectItem(indexPath.item, animated: true, notifySelection: self.pressShouldFireSelectedEvent)
+		self.delegate?.pickerView?(self, didPressItem: indexPath.item)
 	}
 
 	// MARK: UIScrollViewDelegate

--- a/AKPickerView/AKPickerView.swift
+++ b/AKPickerView/AKPickerView.swift
@@ -94,7 +94,7 @@ public class AKCollectionViewCell: UICollectionViewCell {
 	}
 
 	init() {
-		super.init(frame: CGRectZero)
+		super.init(frame: CGRect.zero)
 		self.initialize()
 	}
 
@@ -103,7 +103,7 @@ public class AKCollectionViewCell: UICollectionViewCell {
 		self.initialize()
 	}
 
-	internal init!(coder aDecoder: NSCoder) {
+	required public init!(coder aDecoder: NSCoder) {
 		super.init(coder: aDecoder)
 		self.initialize()
 	}
@@ -120,7 +120,7 @@ private class AKCollectionViewLayout: UICollectionViewFlowLayout {
 	var maxAngle: CGFloat!
 
 	func initialize() {
-		self.sectionInset = UIEdgeInsetsMake(0.0, 0.0, 0.0, 0.0)
+		self.sectionInset = UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0)
 		self.scrollDirection = .Horizontal
 		self.minimumLineSpacing = 0.0
 	}
@@ -137,9 +137,9 @@ private class AKCollectionViewLayout: UICollectionViewFlowLayout {
 
 	private override func prepareLayout() {
 		let visibleRect = CGRect(origin: self.collectionView!.contentOffset, size: self.collectionView!.bounds.size)
-		self.midX = CGRectGetMidX(visibleRect);
-		self.width = CGRectGetWidth(visibleRect) / 2;
-		self.maxAngle = CGFloat(M_PI_2);
+		self.midX = visibleRect.midX
+		self.width = visibleRect.width / 2
+		self.maxAngle = CGFloat(M_PI_2)
 	}
 
 	private override func shouldInvalidateLayoutForBoundsChange(newBounds: CGRect) -> Bool {
@@ -152,18 +152,18 @@ private class AKCollectionViewLayout: UICollectionViewFlowLayout {
             case .Flat:
                 return attributes
             case .Wheel:
-                let distance = CGRectGetMidX(attributes.frame) - self.midX;
-                let currentAngle = self.maxAngle * distance / self.width / CGFloat(M_PI_2);
-                var transform = CATransform3DIdentity;
-                transform = CATransform3DTranslate(transform, -distance, 0, -self.width);
-                transform = CATransform3DRotate(transform, currentAngle, 0, 1, 0);
-                transform = CATransform3DTranslate(transform, 0, 0, self.width);
-                attributes.transform3D = transform;
-                attributes.alpha = fabs(currentAngle) < self.maxAngle ? 1.0 : 0.0;
-                return attributes;
+                let distance = CGRectGetMidX(attributes.frame) - self.midX
+                let currentAngle = self.maxAngle * distance / self.width / CGFloat(M_PI_2)
+                var transform = CATransform3DIdentity
+                transform = CATransform3DTranslate(transform, -distance, 0, -self.width)
+                transform = CATransform3DRotate(transform, currentAngle, 0, 1, 0)
+                transform = CATransform3DTranslate(transform, 0, 0, self.width)
+                attributes.transform3D = transform
+                attributes.alpha = fabs(currentAngle) < self.maxAngle ? 1.0 : 0.0
+                return attributes
             }
         }
-        
+
         return nil
 	}
 
@@ -260,10 +260,10 @@ public class AKPickerView: UIView, UICollectionViewDataSource, UICollectionViewD
 	@IBInspectable public var viewDepth: CGFloat = 1000.0 {
 		didSet {
 			self.collectionView.layer.sublayerTransform = self.viewDepth > 0.0 ? {
-				var transform = CATransform3DIdentity;
-				transform.m34 = -1.0 / self.viewDepth;
-				return transform;
-				}() : CATransform3DIdentity;
+				var transform = CATransform3DIdentity
+				transform.m34 = -1.0 / self.viewDepth
+				return transform
+				}() : CATransform3DIdentity
 		}
 	}
 	/// Readwrite. A boolean value indicates whether the mask is disabled.
@@ -278,8 +278,8 @@ public class AKPickerView: UIView, UICollectionViewDataSource, UICollectionViewD
 					UIColor.blackColor().CGColor,
 					UIColor.clearColor().CGColor]
 				maskLayer.locations = [0.0, 0.33, 0.66, 1.0]
-				maskLayer.startPoint = CGPointMake(0.0, 0.0)
-				maskLayer.endPoint = CGPointMake(1.0, 0.0)
+				maskLayer.startPoint = CGPoint(x: 0.0, y: 0.0)
+				maskLayer.endPoint = CGPoint(x: 1.0, y: 0.0)
 				return maskLayer
 				}()
 		}
@@ -299,7 +299,7 @@ public class AKPickerView: UIView, UICollectionViewDataSource, UICollectionViewD
 
 	// MARK: Private Properties
 	/// Private. A UICollectionView which shows contents on cells.
-	private var collectionView: UICollectionView!
+	public var collectionView: UICollectionView!
 	/// Private. An intercepter to hook UICollectionViewDelegate then throw it picker view and its delegate
 	private var intercepter: AKPickerViewDelegateIntercepter!
 	/// Private. A UICollectionViewFlowLayout used in picker view's collection view.
@@ -334,7 +334,7 @@ public class AKPickerView: UIView, UICollectionViewDataSource, UICollectionViewD
 	}
 
 	public init() {
-		super.init(frame: CGRectZero)
+		super.init(frame: CGRect.zero)
 		self.initialize()
 	}
 
@@ -527,7 +527,7 @@ public class AKPickerView: UIView, UICollectionViewDataSource, UICollectionViewD
 			cell.label.font = self.font
 			cell.font = self.font
 			cell.highlightedFont = self.highlightedFont
-			cell.label.bounds = CGRect(origin: CGPointZero, size: self.sizeForString(title))
+			cell.label.bounds = CGRect(origin: CGPoint.zero, size: self.sizeForString(title))
 			if let delegate = self.delegate {
 				delegate.pickerView?(self, configureLabel: cell.label, forItem: indexPath.item)
 				if let margin = delegate.pickerView?(self, marginForItem: indexPath.item) {
@@ -606,6 +606,5 @@ public class AKPickerView: UIView, UICollectionViewDataSource, UICollectionViewD
 	private func pickerViewStyleForCollectionViewLayout(layout: AKCollectionViewLayout) -> AKPickerViewStyle {
 		return self.pickerViewStyle
 	}
-	
-}
 
+}

--- a/AKPickerView/AKPickerView.swift
+++ b/AKPickerView/AKPickerView.swift
@@ -55,9 +55,9 @@ private protocol AKCollectionViewLayoutDelegate {
 /**
 Private. A subclass of UICollectionViewCell used in AKPickerView's collection view.
 */
-private class AKCollectionViewCell: UICollectionViewCell {
+public class AKCollectionViewCell: UICollectionViewCell {
 	var label: UILabel!
-	var imageView: UIImageView!
+	public var imageView: UIImageView!
 	var font = UIFont.systemFontOfSize(UIFont.systemFontSize())
 	var highlightedFont = UIFont.systemFontOfSize(UIFont.systemFontSize())
 	var _selected: Bool = false {
@@ -103,7 +103,7 @@ private class AKCollectionViewCell: UICollectionViewCell {
 		self.initialize()
 	}
 
-	required init!(coder aDecoder: NSCoder) {
+	internal init!(coder aDecoder: NSCoder) {
 		super.init(coder: aDecoder)
 		self.initialize()
 	}

--- a/AKPickerViewSample.xcodeproj/project.pbxproj
+++ b/AKPickerViewSample.xcodeproj/project.pbxproj
@@ -170,9 +170,11 @@
 				TargetAttributes = {
 					66F602601A8A167C0006FA7E = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0800;
 					};
 					66F6028E1A8A17220006FA7E = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -345,6 +347,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.prioirs.akkyie.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -356,6 +359,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.prioirs.akkyie.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -378,6 +382,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.prioirs.akkyie.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -398,6 +403,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.prioirs.akkyie.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/AKPickerViewSample/ViewController.swift
+++ b/AKPickerViewSample/ViewController.swift
@@ -53,7 +53,9 @@ class ViewController: UIViewController, AKPickerViewDataSource, AKPickerViewDele
 	func pickerView(pickerView: AKPickerView, didSelectItem item: Int) {
 		print("Your favorite city is \(self.titles[item])")
 	}
-
+	func pickerView(pickerView: AKPickerView, didPressItem item: Int) {
+		print("You pressed city: \(self.titles[item])")
+	}
 	/*
 
 	Label Customization

--- a/README.md
+++ b/README.md
@@ -82,11 +82,14 @@ Usage
   self.pickerView.reloadData()
   ```
 
-1. Optional: You can use `AKPickerViewDelegate` methods to observe selection changes:
+1. Optional: You can use `AKPickerViewDelegate` methods to observe selection changes and single taps:
   ```swift
   func pickerView(pickerView: AKPickerView, didSelectItem item: Int) {}
+  func pickerView(pickerView: AKPickerView, didPressItem item: Int) {}
   ```
-  Additionally, you can also use `UIScrollViewDelegate` methods to observe scrolling.
+2. Optional: If you would like to disable `didSelectItem` delegate calls when an item is single tapped, you can do so by setting the `var pressShouldFireSelectedEvent` to `false`.
+
+Additionally, you can also use `UIScrollViewDelegate` methods to observe scrolling.
 
 For more detail, see the sample project.
 


### PR DESCRIPTION
This pull request adds an optional delegate method `pickerView(pickerView: AKPickerView, didPressItem: Int)` to fire a separate event when an item is single tapped. It also adds a public flag to disable `didSelectItem:` delegate method calls if a user would prefer to receive `didSelectItem:` delegate method calls only when an item is scrolled to, not when
an item is single tapped. This commit should be backward compatible with existing codebases.
