### PR TITLE
Fixes wrong signature for layoutAttributesForElements(in:)

### DIFF
--- a/AKPickerView/AKPickerView.swift
+++ b/AKPickerView/AKPickerView.swift
@@ -165,13 +165,13 @@ private class AKCollectionViewLayout: UICollectionViewFlowLayout {
 
 		return nil
 	}
-
-	private func layoutAttributesForElementsInRect(_ rect: CGRect) -> [AnyObject]? {
+    
+    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
 		switch self.delegate.pickerViewStyleForCollectionViewLayout(self) {
 		case .flat:
 			return super.layoutAttributesForElements(in: rect)
 		case .wheel:
-			var attributes = [AnyObject]()
+			var attributes = [UICollectionViewLayoutAttributes]()
 			if self.collectionView!.numberOfSections > 0 {
 				for i in 0 ..< self.collectionView!.numberOfItems(inSection: 0) {
 					let indexPath = IndexPath(item: i, section: 0)


### PR DESCRIPTION
Fixes #70. PR #46 is also related to this but doesn't work in Swift 3.