### PR TITLE
Fix a potential crash when reloading data

### DIFF
--- a/AKPickerView/AKPickerView.swift
+++ b/AKPickerView/AKPickerView.swift
@@ -421,7 +421,7 @@ public class AKPickerView: UIView, UICollectionViewDataSource, UICollectionViewD
 		self.collectionView.collectionViewLayout.invalidateLayout()
 		self.collectionView.reloadData()
 		if self.dataSource != nil && self.dataSource!.numberOfItemsInPickerView(self) > 0 {
-			self.selectItem(self.selectedItem, animated: false, notifySelection: false)
+            self.selectItem(0, animated: false, notifySelection: false)
 		}
 	}
 


### PR DESCRIPTION
If the currently selected item is greater than the bounds of the newer number of items then the code will crash.